### PR TITLE
Upgrade to Wren 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wren"
-version = "0.1.12"
+version = "0.3.0"
 authors = ["Calvin Ikenberry"]
 description = "Bindings to the Wren scripting language API"
 readme = "README.md"
@@ -11,7 +11,7 @@ repository = "https://github.com/calviken/wren-rust"
 documentation = "https://docs.rs/wren"
 
 [dependencies.wren-sys]
-version = "~0.2.3"
+version = "~0.3.0"
 path = "./wren-sys"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# wren-rust 
-[![Crates.io](https://img.shields.io/crates/v/wren.svg)](https://crates.io/crates/wren)
-[![Documentation](https://docs.rs/wren/badge.svg)](https://docs.rs/wren)
-
+# wren-rust [![Crates.io](https://img.shields.io/crates/v/wren.svg)](https://crates.io/crates/wren) [![Documentation](https://docs.rs/wren/badge.svg)](https://docs.rs/wren)
 Rust bindings to the [Wren scripting language](http://wren.io) API.
 
+Crate documentation is somewhat lacking at the moment.
+For complete documentation on each type and function, refer to `wren.h` in the [official Wren repository](http://github.com/munificent/wren).
+
+Wren is still under heavy development. 
+I'll do my best to keep these bindings up-to-date as new features are added.
+If you notice a missing feature, feel free to create an issue or pull request.
+
 # Safety
-Wren doesn't do any kind of validation outside of a few assertions in debug builds. This means it's very easy to get Undefined Behavior in release builds if you're not careful (especially when processing arbitrary scripts).
+Wren doesn't do any kind of validation outside of a few assertions in debug builds. 
+This means it's very easy to get Undefined Behavior in release builds if you're not careful (especially when processing arbitrary scripts).
 
-Some functions are still not checked regarding upgraded C API.
+Most functions in this crate include additional safety features to help avoid these problems. In particular:
 
-# Todo
-
-* Support Wren standard lib (option headers)
-
-## References
-
-* Another [Wren lib in Rust](https://github.com/Laegluin/wren-sys)
-* Wrap some unsafe functions so you don't hit by undefined behaviour.
+1. Functions that retrieve slot values will perform type checking and return an Option.
+2. `wrenEnsureSlots` is called automatically when setting slot values.
+3. Most functions validate their parameters before calling Wren. 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# wren-rust [![Crates.io](https://img.shields.io/crates/v/wren.svg)](https://crates.io/crates/wren) [![Documentation](https://docs.rs/wren/badge.svg)](https://docs.rs/wren)
+# wren-rust 
+[![Crates.io](https://img.shields.io/crates/v/wren.svg)](https://crates.io/crates/wren)
+[![Documentation](https://docs.rs/wren/badge.svg)](https://docs.rs/wren)
+
 Rust bindings to the [Wren scripting language](http://wren.io) API.
 
-Crate documentation is somewhat lacking at the moment.
-For complete documentation on each type and function, refer to `wren.h` in the [official Wren repository](http://github.com/munificent/wren).
-
-Wren is still under heavy development. 
-I'll do my best to keep these bindings up-to-date as new features are added.
-If you notice a missing feature, feel free to create an issue or pull request.
-
 # Safety
-Wren doesn't do any kind of validation outside of a few assertions in debug builds. 
-This means it's very easy to get Undefined Behavior in release builds if you're not careful (especially when processing arbitrary scripts).
+Wren doesn't do any kind of validation outside of a few assertions in debug builds. This means it's very easy to get Undefined Behavior in release builds if you're not careful (especially when processing arbitrary scripts).
 
-Most functions in this crate include additional safety features to help avoid these problems. In particular:
+Some functions are still not checked regarding upgraded C API.
 
-1. Functions that retrieve slot values will perform type checking and return an Option.
-2. `wrenEnsureSlots` is called automatically when setting slot values.
-3. Most functions validate their parameters before calling Wren. 
+# Todo
+
+* Support Wren standard lib (option headers)
+
+## References
+
+* Another [Wren lib in Rust](https://github.com/Laegluin/wren-sys)
+* Wrap some unsafe functions so you don't hit by undefined behaviour.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,14 +16,14 @@ pub use ffi::WrenErrorType as ErrorType;
 pub use ffi::WrenInterpretResult as InterpretResult;
 pub use ffi::WrenType as Type;
 
-pub use ffi::WrenReallocateFn as ReallocateFn;
-pub use ffi::WrenForeignMethodFn as ForeignMethodFn;
-pub use ffi::WrenFinalizerFn as FinalizerFn;
-pub use ffi::WrenLoadModuleFn as LoadModuleFn;
-pub use ffi::WrenBindForeignMethodFn as BindForeignMethodFn;
 pub use ffi::WrenBindForeignClassFn as BindForeignClassFn;
-pub use ffi::WrenWriteFn as WriteFn;
+pub use ffi::WrenBindForeignMethodFn as BindForeignMethodFn;
 pub use ffi::WrenErrorFn as ErrorFn;
+pub use ffi::WrenFinalizerFn as FinalizerFn;
+pub use ffi::WrenForeignMethodFn as ForeignMethodFn;
+pub use ffi::WrenLoadModuleFn as LoadModuleFn;
+pub use ffi::WrenReallocateFn as ReallocateFn;
+pub use ffi::WrenWriteFn as WriteFn;
 
 pub use self::vm::Configuration;
 pub use self::vm::ForeignClassMethods;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,51 +1,67 @@
+use ffi;
+use libc::*;
+use std::ffi::{CStr, CString};
 use std::mem;
 use std::ptr;
-use std::ffi::{CStr, CString};
-use libc::*;
-use ffi;
-use VM;
-use Pointer;
 use ErrorType;
+use Pointer;
+use VM;
 
 /// Wrap a `Fn(Pointer, usize) -> Pointer` as an ffi-suitable `ReallocateFn`.
 #[macro_export]
-macro_rules! wren_reallocate_fn{ ($f:path) => { $crate::macros::_wrap_reallocate_fn($f) } }
+macro_rules! wren_reallocate_fn {
+    ($f:path) => {
+        $crate::macros::_wrap_reallocate_fn($f)
+    };
+}
 
 /// Wrap a `Fn(&mut VM)` as an ffi-suitable `ForeignMethodFn`.
 #[macro_export]
-macro_rules! wren_foreign_method_fn{ ($f:path) => { $crate::macros::_wrap_foreign_method_fn($f) } }
+macro_rules! wren_foreign_method_fn {
+    ($f:path) => {
+        $crate::macros::_wrap_foreign_method_fn($f)
+    };
+}
 
 /// Wrap a `Fn(Pointer)` as an ffi-suitable `FinalizerFn`.
 #[macro_export]
-macro_rules! wren_finalizer_fn{ ($f:path) => { $crate::macros::_wrap_finalizer_fn($f) } }
-
-/// Wrap a `Fn(&mut VM, &str) -> Option<String>` as an ffi-suitable `LoadModuleFn`.
-///
-/// Note: If a custom allocator is being used, it must be passed to this macro as well.
-/// This isn't required when using the default allocator.
-#[macro_export]
-macro_rules! wren_load_module_fn{
-    ($f:path) => { $crate::macros::_wrap_load_module_fn($f, $crate::macros::_default_realloc) };
-    ($f:path, $alloc:path) => { $crate::macros::_wrap_load_module_fn($f, $alloc) };
+macro_rules! wren_finalizer_fn {
+    ($f:path) => {
+        $crate::macros::_wrap_finalizer_fn($f)
+    };
 }
 
 /// Wrap a `Fn(&mut VM, &str, &str, bool, &str) -> ForeignMethodFn` as an ffi-suitable `BindForeignMethodFn`.
 #[macro_export]
-macro_rules! wren_bind_foreign_method_fn{ ($f:path) => { $crate::macros::_wrap_bind_foreign_method_fn($f) } }
+macro_rules! wren_bind_foreign_method_fn {
+    ($f:path) => {
+        $crate::macros::_wrap_bind_foreign_method_fn($f)
+    };
+}
 
 /// Wrap a `Fn(&mut VM, &str, &str) -> ForeignClassMethods` as an ffi-suitable `BindForeignClassFn`.
 #[macro_export]
-macro_rules! wren_bind_foreign_class_fn{ ($f:path) => { $crate::macros::_wrap_bind_foreign_class_fn($f) } }
+macro_rules! wren_bind_foreign_class_fn {
+    ($f:path) => {
+        $crate::macros::_wrap_bind_foreign_class_fn($f)
+    };
+}
 
 /// Wrap a `Fn(&mut VM, &str)` as an ffi-suitable `WriteFn`.
 #[macro_export]
-macro_rules! wren_write_fn{ ($f:path) => { $crate::macros::_wrap_write_fn($f) } }
+macro_rules! wren_write_fn {
+    ($f:path) => {
+        $crate::macros::_wrap_write_fn($f)
+    };
+}
 
 /// Wrap a `Fn(&mut VM, ErrorType, &str, i32, &str)` as an ffi-suitable `ErrorFn`.
 #[macro_export]
-macro_rules! wren_error_fn{ ($f:path) => { $crate::macros::_wrap_error_fn($f) } }
-
-
+macro_rules! wren_error_fn {
+    ($f:path) => {
+        $crate::macros::_wrap_error_fn($f)
+    };
+}
 
 #[doc(hidden)]
 #[inline]
@@ -67,9 +83,11 @@ fn _assert_size<F>() {
 #[doc(hidden)]
 #[inline]
 pub fn _wrap_reallocate_fn<F: Fn(Pointer, usize) -> Pointer>(_: F) -> ::ReallocateFn {
-    unsafe extern "C" fn f<F: Fn(Pointer, usize) -> Pointer>(data: *mut c_void,
-                                                             new_size: size_t)
-                                                             -> *mut c_void {
+    unsafe extern "C" fn f<F: Fn(Pointer, usize) -> Pointer>(
+        memory: *mut c_void,
+        new_size: size_t,
+        data: *mut c_void,
+    ) -> *mut c_void {
         mem::transmute::<&(), &F>(&())(data, new_size)
     }
     _assert_size::<F>();
@@ -98,50 +116,19 @@ pub fn _wrap_finalizer_fn<F: Fn(Pointer)>(_: F) -> ::FinalizerFn {
 
 #[doc(hidden)]
 #[inline]
-pub fn _wrap_load_module_fn<F: Fn(&mut VM, &str) -> Option<String>,
-                            Alloc: Fn(*mut c_void, size_t) -> *mut c_void>
-    (_: F,
-     _: Alloc)
-     -> ::LoadModuleFn {
-    unsafe extern "C" fn f<F: Fn(&mut VM, &str) -> Option<String>,
-                           Alloc: Fn(*mut c_void, size_t) -> *mut c_void>
-        (vm: *mut ffi::WrenVM,
-         name: *const c_char)
-         -> *mut c_char {
-
-        let mut vm = VM::from_ptr(vm);
-        let name = CStr::from_ptr(name).to_str().unwrap();
-        let source = mem::transmute::<&(), &F>(&())(&mut vm, name);
-        if let Some(source) = source {
-            let len = source.len() + 1; // One extra byte for the null terminator.
-            let source_cstr = CString::new(source).unwrap();
-            let buffer = mem::transmute::<&(), &Alloc>(&())(ptr::null_mut(), len);
-            memcpy(buffer, source_cstr.as_ptr() as *mut c_void, len);
-            buffer as *mut c_char
-        } else {
-            ptr::null_mut()
-        }
-    }
-    _assert_size::<F>();
-    Some(f::<F, Alloc>)
-}
-
-#[doc(hidden)]
-#[inline]
-pub fn _wrap_bind_foreign_method_fn<F: Fn(&mut VM, &str, &str, bool, &str) -> ::ForeignMethodFn>
-    (_: F)
-     -> ::BindForeignMethodFn {
-    unsafe extern "C" fn f<F: Fn(&mut VM, &str, &str, bool, &str) -> ::ForeignMethodFn>
-        (vm: *mut ffi::WrenVM,
-         module: *const c_char,
-         class_name: *const c_char,
-         is_static: c_int,
-         signature: *const c_char)
-         -> ::ForeignMethodFn {
+pub fn _wrap_bind_foreign_method_fn<F: Fn(&mut VM, &str, &str, bool, &str) -> ::ForeignMethodFn>(
+    _: F,
+) -> ::BindForeignMethodFn {
+    unsafe extern "C" fn f<F: Fn(&mut VM, &str, &str, bool, &str) -> ::ForeignMethodFn>(
+        vm: *mut ffi::WrenVM,
+        module: *const c_char,
+        class_name: *const c_char,
+        is_static: bool,
+        signature: *const c_char,
+    ) -> ::ForeignMethodFn {
         let mut vm = VM::from_ptr(vm);
         let module = CStr::from_ptr(module).to_str().unwrap();
         let class_name = CStr::from_ptr(class_name).to_str().unwrap();
-        let is_static = is_static != 0;
         let signature = CStr::from_ptr(signature).to_str().unwrap();
         mem::transmute::<&(), &F>(&())(&mut vm, module, class_name, is_static, signature)
     }
@@ -151,14 +138,14 @@ pub fn _wrap_bind_foreign_method_fn<F: Fn(&mut VM, &str, &str, bool, &str) -> ::
 
 #[doc(hidden)]
 #[inline]
-pub fn _wrap_bind_foreign_class_fn<F: Fn(&mut VM, &str, &str) -> ::ForeignClassMethods>
-    (_: F)
-     -> ::BindForeignClassFn {
-    unsafe extern "C" fn f<F: Fn(&mut VM, &str, &str) -> ::ForeignClassMethods>
-        (vm: *mut ffi::WrenVM,
-         module: *const c_char,
-         class_name: *const c_char)
-         -> ffi::WrenForeignClassMethods {
+pub fn _wrap_bind_foreign_class_fn<F: Fn(&mut VM, &str, &str) -> ::ForeignClassMethods>(
+    _: F,
+) -> ::BindForeignClassFn {
+    unsafe extern "C" fn f<F: Fn(&mut VM, &str, &str) -> ::ForeignClassMethods>(
+        vm: *mut ffi::WrenVM,
+        module: *const c_char,
+        class_name: *const c_char,
+    ) -> ffi::WrenForeignClassMethods {
         let mut vm = VM::from_ptr(vm);
         let module = CStr::from_ptr(module).to_str().unwrap();
         let class_name = CStr::from_ptr(class_name).to_str().unwrap();
@@ -172,8 +159,10 @@ pub fn _wrap_bind_foreign_class_fn<F: Fn(&mut VM, &str, &str) -> ::ForeignClassM
 #[inline]
 pub fn _wrap_write_fn<F: Fn(&mut VM, &str)>(_: F) -> ::WriteFn {
     unsafe extern "C" fn f<F: Fn(&mut VM, &str)>(vm: *mut ffi::WrenVM, text: *const c_char) {
-        mem::transmute::<&(), &F>(&())(&mut VM::from_ptr(vm),
-                                       CStr::from_ptr(text).to_str().unwrap());
+        mem::transmute::<&(), &F>(&())(
+            &mut VM::from_ptr(vm),
+            CStr::from_ptr(text).to_str().unwrap(),
+        );
     }
     _assert_size::<F>();
     Some(f::<F>)
@@ -182,11 +171,13 @@ pub fn _wrap_write_fn<F: Fn(&mut VM, &str)>(_: F) -> ::WriteFn {
 #[doc(hidden)]
 #[inline]
 pub fn _wrap_error_fn<F: Fn(&mut VM, ErrorType, &str, i32, &str)>(_: F) -> ::ErrorFn {
-    unsafe extern "C" fn f<F: Fn(&mut VM, ErrorType, &str, i32, &str)>(vm: *mut ffi::WrenVM,
-                                                                       _type: ffi::WrenErrorType,
-                                                                       module: *const c_char,
-                                                                       line: c_int,
-                                                                       message: *const c_char) {
+    unsafe extern "C" fn f<F: Fn(&mut VM, ErrorType, &str, i32, &str)>(
+        vm: *mut ffi::WrenVM,
+        _type: ffi::WrenErrorType,
+        module: *const c_char,
+        line: c_int,
+        message: *const c_char,
+    ) {
         let mut vm = VM::from_ptr(vm);
         let module = if module == ptr::null() {
             ""

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 use ffi;
 use libc::*;
-use std::ffi::{CStr, CString};
+use std::ffi::{CStr};
 use std::mem;
 use std::ptr;
 use ErrorType;
@@ -84,7 +84,7 @@ fn _assert_size<F>() {
 #[inline]
 pub fn _wrap_reallocate_fn<F: Fn(Pointer, usize) -> Pointer>(_: F) -> ::ReallocateFn {
     unsafe extern "C" fn f<F: Fn(Pointer, usize) -> Pointer>(
-        memory: *mut c_void,
+        _memory: *mut c_void,
         new_size: size_t,
         data: *mut c_void,
     ) -> *mut c_void {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use {VM, Configuration};
+use {Configuration, VM};
 
 #[test]
 fn list() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -19,6 +19,7 @@ fn default_error(_: &mut VM, _type: ErrorType, module: &str, line: i32, message:
     }
 }
 
+#[allow(dead_code)]
 fn default_load_module(_: &mut VM, name: &str) -> Option<String> {
     use std::fs::File;
     use std::io::Read;
@@ -65,7 +66,6 @@ impl Configuration {
         let mut cfg = Configuration(raw);
         cfg.set_write_fn(wren_write_fn!(default_write));
         cfg.set_error_fn(wren_error_fn!(default_error));
-        // cfg.set_load_module_fn(wren_load_module_fn!(default_load_module));
         cfg
     }
 

--- a/wren-sys/Cargo.toml
+++ b/wren-sys/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "wren-sys"
-version = "0.2.5"
+version = "0.3.0"
 authors = ["Calvin Ikenberry"]
 description = "FFI bindings to the Wren scripting language API"
+edition = "2018"
 readme = "README.md"
 keywords = ["wren", "bindings", "ffi"]
 license = "MIT"

--- a/wren-sys/README.md
+++ b/wren-sys/README.md
@@ -1,3 +1,14 @@
-# wren-sys [![Crates.io](https://img.shields.io/crates/v/wren-sys.svg)](https://crates.io/crates/wren-sys) [![Documentation](https://docs.rs/wren-sys/badge.svg)](https://docs.rs/wren-sys)
+# wren-sys 
+
+[![Crates.io](https://img.shields.io/crates/v/wren-sys.svg)](https://crates.io/crates/wren-sys)
+[![Documentation](https://docs.rs/wren-sys/badge.svg)](https://docs.rs/wren-sys)
 
 Rust FFI bindings to the [Wren scripting language](http://wren.io) API.
+
+## Build
+
+This creates static lib in `./wren/lib`.
+
+```bash
+cargo build --release
+```

--- a/wren-sys/build.rs
+++ b/wren-sys/build.rs
@@ -1,6 +1,6 @@
-use std::process::Command;
-use std::path::Path;
 use std::env;
+use std::path::Path;
+use std::process::Command;
 
 #[allow(dead_code)]
 fn make_debug(dir: &Path) {
@@ -15,7 +15,6 @@ fn make_release(dir: &Path) {
     assert!(status.unwrap().success());
     println!("cargo:rustc-link-lib=static=wren");
 }
-
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();

--- a/wren-sys/src/lib.rs
+++ b/wren-sys/src/lib.rs
@@ -1,26 +1,55 @@
+#![allow(non_camel_case_types, non_snake_case, dead_code)]
 #![allow(improper_ctypes)]
 
 extern crate libc;
-use libc::{c_void, size_t, c_char, c_int, c_double};
+use libc::{c_char, c_int, c_void, size_t};
 
 #[repr(C)]
-pub struct WrenVM;
+#[derive(Debug, Copy, Clone)]
+pub struct WrenVM {}
 
 #[repr(C)]
-pub struct WrenHandle;
+#[derive(Debug, Copy, Clone)]
+pub struct WrenHandle {}
 
-pub type WrenReallocateFn = Option<unsafe extern "C" fn(memory: *mut c_void, new_size: size_t)
-                                                        -> *mut c_void>;
+pub type WrenReallocateFn = Option<
+    unsafe extern "C" fn(
+        memory: *mut c_void,
+        newSize: size_t,
+        userData: *mut c_void,
+    ) -> *mut c_void,
+>;
 pub type WrenForeignMethodFn = Option<unsafe extern "C" fn(vm: *mut WrenVM)>;
 pub type WrenFinalizerFn = Option<unsafe extern "C" fn(data: *mut c_void)>;
-pub type WrenLoadModuleFn = Option<unsafe extern "C" fn(vm: *mut WrenVM, name: *const c_char)
-                                                        -> *mut c_char>;
-pub type WrenBindForeignMethodFn = Option<unsafe extern "C" fn(vm: *mut WrenVM,
-                                                               module: *const c_char,
-                                                               class_name: *const c_char,
-                                                               is_static: c_int,
-                                                               signature: *const c_char)
-                                                               -> WrenForeignMethodFn>;
+pub type WrenResolveModuleFn = Option<
+    unsafe extern "C" fn(
+        vm: *mut WrenVM,
+        importer: *const c_char,
+        name: *const c_char,
+    ) -> *const c_char,
+>;
+pub type WrenLoadModuleCompleteFn = Option<
+    unsafe extern "C" fn(vm: *mut WrenVM, name: *const c_char, result: WrenLoadModuleResult),
+>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct WrenLoadModuleResult {
+    pub source: *const c_char,
+    pub onComplete: WrenLoadModuleCompleteFn,
+    pub userData: *mut c_void,
+}
+pub type WrenLoadModuleFn =
+    Option<unsafe extern "C" fn(vm: *mut WrenVM, name: *const c_char) -> WrenLoadModuleResult>;
+
+pub type WrenBindForeignMethodFn = Option<
+    unsafe extern "C" fn(
+        vm: *mut WrenVM,
+        module: *const c_char,
+        className: *const c_char,
+        isStatic: bool,
+        signature: *const c_char,
+    ) -> WrenForeignMethodFn,
+>;
 pub type WrenWriteFn = Option<unsafe extern "C" fn(vm: *mut WrenVM, text: *const c_char)>;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -30,28 +59,35 @@ pub enum WrenErrorType {
     Runtime,
     StackTrace,
 }
+pub type WrenErrorFn = Option<
+    unsafe extern "C" fn(
+        vm: *mut WrenVM,
+        type_: WrenErrorType,
+        module: *const c_char,
+        line: c_int,
+        message: *const c_char,
+    ),
+>;
 
-pub type WrenErrorFn = Option<unsafe extern "C" fn(vm: *mut WrenVM,
-                                                   _type: WrenErrorType,
-                                                   module: *const c_char,
-                                                   line: c_int,
-                                                   message: *const c_char)>;
-
-#[derive(Copy, Clone)]
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct WrenForeignClassMethods {
     pub allocate: WrenForeignMethodFn,
     pub finalize: WrenFinalizerFn,
 }
-
-pub type WrenBindForeignClassFn = Option<unsafe extern "C" fn(vm: *mut WrenVM,
-                                                              module: *const c_char,
-                                                              class_name: *const c_char)
-                                                              -> WrenForeignClassMethods>;
+pub type WrenBindForeignClassFn = Option<
+    unsafe extern "C" fn(
+        vm: *mut WrenVM,
+        module: *const c_char,
+        className: *const c_char,
+    ) -> WrenForeignClassMethods,
+>;
 
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
 pub struct WrenConfiguration {
     pub reallocate_fn: WrenReallocateFn,
+    pub resolve_module_fn: WrenResolveModuleFn,
     pub load_module_fn: WrenLoadModuleFn,
     pub bind_foreign_method_fn: WrenBindForeignMethodFn,
     pub bind_foreign_class_fn: WrenBindForeignClassFn,
@@ -89,44 +125,60 @@ extern "C" {
     pub fn wrenFreeVM(vm: *mut WrenVM);
     pub fn wrenCollectGarbage(vm: *mut WrenVM);
     pub fn wrenInterpret(vm: *mut WrenVM, source: *const c_char) -> WrenInterpretResult;
+    pub fn wrenInterpretInModule(
+        vm: *mut WrenVM,
+        module: *const c_char,
+        source: *const c_char,
+    ) -> WrenInterpretResult;
     pub fn wrenMakeCallHandle(vm: *mut WrenVM, signature: *const c_char) -> *mut WrenHandle;
     pub fn wrenCall(vm: *mut WrenVM, method: *mut WrenHandle) -> WrenInterpretResult;
     pub fn wrenReleaseHandle(vm: *mut WrenVM, handle: *mut WrenHandle);
-
     pub fn wrenGetSlotCount(vm: *mut WrenVM) -> c_int;
-    pub fn wrenEnsureSlots(vm: *mut WrenVM, num_slots: c_int);
+    pub fn wrenEnsureSlots(vm: *mut WrenVM, numSlots: c_int);
     pub fn wrenGetSlotType(vm: *mut WrenVM, slot: c_int) -> WrenType;
-    pub fn wrenGetSlotBool(vm: *mut WrenVM, slot: c_int) -> c_int;
+    pub fn wrenGetSlotBool(vm: *mut WrenVM, slot: c_int) -> bool;
     pub fn wrenGetSlotBytes(vm: *mut WrenVM, slot: c_int, length: *mut c_int) -> *const c_char;
-    pub fn wrenGetSlotDouble(vm: *mut WrenVM, slot: c_int) -> c_double;
+    pub fn wrenGetSlotDouble(vm: *mut WrenVM, slot: c_int) -> f64;
     pub fn wrenGetSlotForeign(vm: *mut WrenVM, slot: c_int) -> *mut c_void;
     pub fn wrenGetSlotString(vm: *mut WrenVM, slot: c_int) -> *const c_char;
     pub fn wrenGetSlotHandle(vm: *mut WrenVM, slot: c_int) -> *mut WrenHandle;
-
-    pub fn wrenSetSlotBool(vm: *mut WrenVM, slot: c_int, value: c_int);
+    pub fn wrenSetSlotBool(vm: *mut WrenVM, slot: c_int, value: bool);
     pub fn wrenSetSlotBytes(vm: *mut WrenVM, slot: c_int, bytes: *const c_char, length: size_t);
-    pub fn wrenSetSlotDouble(vm: *mut WrenVM, slot: c_int, value: c_double);
-    pub fn wrenSetSlotNewForeign(vm: *mut WrenVM,
-                                 slot: c_int,
-                                 class_slot: c_int,
-                                 size: size_t)
-                                 -> *mut c_void;
+    pub fn wrenSetSlotDouble(vm: *mut WrenVM, slot: c_int, value: f64);
+    pub fn wrenSetSlotNewForeign(
+        vm: *mut WrenVM,
+        slot: c_int,
+        classSlot: c_int,
+        size: size_t,
+    ) -> *mut c_void;
     pub fn wrenSetSlotNewList(vm: *mut WrenVM, slot: c_int);
+    pub fn wrenSetSlotNewMap(vm: *mut WrenVM, slot: c_int);
     pub fn wrenSetSlotNull(vm: *mut WrenVM, slot: c_int);
     pub fn wrenSetSlotString(vm: *mut WrenVM, slot: c_int, text: *const c_char);
     pub fn wrenSetSlotHandle(vm: *mut WrenVM, slot: c_int, handle: *mut WrenHandle);
-
     pub fn wrenGetListCount(vm: *mut WrenVM, slot: c_int) -> c_int;
-    pub fn wrenGetListElement(vm: *mut WrenVM,
-                              list_slot: c_int,
-                              index: c_int,
-                              element_slot: c_int);
-    pub fn wrenInsertInList(vm: *mut WrenVM, list_slot: c_int, index: c_int, element_slot: c_int);
-    pub fn wrenGetVariable(vm: *mut WrenVM,
-                           module: *const c_char,
-                           name: *const c_char,
-                           slot: c_int);
+    pub fn wrenGetListElement(vm: *mut WrenVM, listSlot: c_int, index: c_int, elementSlot: c_int);
+    pub fn wrenSetListElement(vm: *mut WrenVM, listSlot: c_int, index: c_int, elementSlot: c_int);
+    pub fn wrenInsertInList(vm: *mut WrenVM, listSlot: c_int, index: c_int, elementSlot: c_int);
+    pub fn wrenGetMapCount(vm: *mut WrenVM, slot: c_int) -> c_int;
+    pub fn wrenGetMapContainsKey(vm: *mut WrenVM, mapSlot: c_int, keySlot: c_int) -> bool;
+    pub fn wrenGetMapValue(vm: *mut WrenVM, mapSlot: c_int, keySlot: c_int, valueSlot: c_int);
+    pub fn wrenSetMapValue(vm: *mut WrenVM, mapSlot: c_int, keySlot: c_int, valueSlot: c_int);
+    pub fn wrenRemoveMapValue(
+        vm: *mut WrenVM,
+        mapSlot: c_int,
+        keySlot: c_int,
+        removedValueSlot: c_int,
+    );
+    pub fn wrenGetVariable(
+        vm: *mut WrenVM,
+        module: *const c_char,
+        name: *const c_char,
+        slot: c_int,
+    );
+    pub fn wrenHasVariable(vm: *mut WrenVM, module: *const c_char, name: *const c_char) -> bool;
+    pub fn wrenHasModule(vm: *mut WrenVM, module: *const c_char) -> bool;
     pub fn wrenAbortFiber(vm: *mut WrenVM, slot: c_int);
     pub fn wrenGetUserData(vm: *mut WrenVM) -> *mut c_void;
-    pub fn wrenSetUserData(vm: *mut WrenVM, user_data: *mut c_void);
+    pub fn wrenSetUserData(vm: *mut WrenVM, userData: *mut c_void);
 }


### PR DESCRIPTION
I'm planning to use the lib for a project so I upgraded the API to latest Wren release. There are a couple of changes:

* `bool` from C is no longer a `int`, but built-in Rust `bool`
* Regenerated C bindings and modified accordingly (new things added)
* Removed one wrapper function from `macros.rs` because the load module function return type has changed (used to be `*cstr`) and requires additional structure initialization, so I simply tailored it..

Optional features come in Wren `include/optional` are still not there. But plan on it. See if the PR can be merged.